### PR TITLE
merge all patch

### DIFF
--- a/Rapfi/search/ab/parameter.h
+++ b/Rapfi/search/ab/parameter.h
@@ -69,9 +69,9 @@ constexpr Value razorVerifyMargin(Depth d)
 }
 
 /// Static futility pruning depth & margins
-constexpr Value futilityMargin(Depth d, bool improving)
+constexpr Value futilityMargin(Depth d, bool noTtCutNode, bool improving)
 {
-    return Value(std::max(int(55 * (d - improving)), 0));
+    return Value(std::max(int((55 - 14 * noTtCutNode) * (d - improving)), 0));
 }
 
 /// Null move pruning margin


### PR DESCRIPTION
This patch was inspired by the original attempts of many people on SF fishtest
Adjust reduction less at medium depths
Mix alpha and statScore for reduction
Futility pruning depth-1
Futility pruning depth<9
newdepth
reduce if score improvement
Do more futility pruning

Task: Adjust reduction less at medium depths vs master  renju LTC
Candidates: weight_807e898d@engine_826fda5a vs weight_807e898d@engine_99baa2df + 
Book: r15-100M-40k
TC: 60+0.6
Total/Win/Draw/Lose: 1088 / 497 / 277 / 314
PTNML: 36 / 61 / 231 / 116 / 100
WinRate: 58.41%
ELO: 58.19[39.48, 77.68]
LOS: 100.00
LLR: 3.16[-2.94, 2.94]